### PR TITLE
Fix(activities): Correct image upload and data handling

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -20,7 +20,7 @@ export interface Database {
           roll_number: string | null;
           event: string;
           date: string;
-          photo_data: string | null;
+          photo_url: string | null;
           year: string;
           is_week_winner: boolean | null;
           created_at: string | null;
@@ -31,7 +31,7 @@ export interface Database {
           roll_number?: string | null;
           event: string;
           date: string;
-          photo_data?: string | null;
+          photo_url?: string | null;
           year?: string;
           is_week_winner?: boolean | null;
           created_at?: string | null;
@@ -42,7 +42,7 @@ export interface Database {
           roll_number?: string | null;
           event?: string;
           date?: string;
-          photo_data?: string | null;
+          photo_url?: string | null;
           year?: string;
           is_week_winner?: boolean | null;
           created_at?: string | null;
@@ -54,7 +54,7 @@ export interface Database {
           title: string;
           description: string | null;
           activity_date: string;
-          poster_data: string | null;
+          poster_url: string | null;
           details: string | null;
           created_at: string | null;
         };
@@ -63,7 +63,7 @@ export interface Database {
           title: string;
           description?: string | null;
           activity_date: string;
-          poster_data?: string | null;
+          poster_url?: string | null;
           details?: string | null;
           created_at?: string | null;
         };
@@ -72,7 +72,7 @@ export interface Database {
           title?: string;
           description?: string | null;
           activity_date?: string;
-          poster_data?: string | null;
+          poster_url?: string | null;
           details?: string | null;
           created_at?: string | null;
         };
@@ -83,9 +83,9 @@ export interface Database {
           title: string;
           description: string | null;
           activity_date: string;
-          poster_data: string | null;
+          poster_url: string | null;
           details: string | null;
-          photos_data: string[] | null;
+          photos: string[] | null;
           created_at: string | null;
         };
         Insert: {
@@ -93,9 +93,9 @@ export interface Database {
           title: string;
           description?: string | null;
           activity_date: string;
-          poster_data?: string | null;
+          poster_url?: string | null;
           details?: string | null;
-          photos_data?: string[] | null;
+          photos?: string[] | null;
           created_at?: string | null;
         };
         Update: {
@@ -103,9 +103,9 @@ export interface Database {
           title?: string;
           description?: string | null;
           activity_date?: string;
-          poster_data?: string | null;
+          poster_url?: string | null;
           details?: string | null;
-          photos_data?: string[] | null;
+          photos?: string[] | null;
           created_at?: string | null;
         };
       };
@@ -113,19 +113,19 @@ export interface Database {
         Row: {
           id: number;
           title: string | null;
-          image_data: string;
+          image_url: string;
           uploaded_at: string | null;
         };
         Insert: {
           id?: number;
           title?: string | null;
-          image_data: string;
+          image_url: string;
           uploaded_at?: string | null;
         };
         Update: {
           id?: number;
           title?: string | null;
-          image_data?: string;
+          image_url?: string;
           uploaded_at?: string | null;
         };
       };

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -107,7 +107,7 @@ const Admin = () => {
     try {
       let posterUrl = editingActivity?.poster || '';
       if (newActivity.poster instanceof File) {
-        const uploadedUrl = await DataService.uploadImage(newActivity.poster, 'activity-posters');
+        const uploadedUrl = await DataService.uploadImage(newActivity.poster, 'activity_posters');
         if (!uploadedUrl) throw new Error("Poster image upload failed");
         posterUrl = uploadedUrl;
       }


### PR DESCRIPTION
This commit resolves two issues that prevented activity images from being uploaded and managed correctly:

1.  **Fix bucket name for activity posters:** The code was attempting to upload to a bucket named `activity-posters` (with a hyphen), while the actual bucket in Supabase was named `activity_posters` (with an underscore). This has been corrected in `Admin.tsx`.

2.  **Align TypeScript types with DB schema:** The TypeScript definitions in `supabase.ts` were out of sync with the actual database schema. The schema uses `_url` suffixes for image columns (e.g., `poster_url`), but the types used `_data` (e.g., `poster_data`). This mismatch has been corrected for all tables (`winners`, `upcoming_activities`, `previous_activities`, `gallery`), ensuring data is handled correctly throughout the application.